### PR TITLE
wip: example with deno

### DIFF
--- a/examples/ipfs-101-deno/hello.txt
+++ b/examples/ipfs-101-deno/hello.txt
@@ -1,0 +1,1 @@
+Hello, how are you today? Welcome to the Distributed Web!

--- a/examples/ipfs-101-deno/index.ts
+++ b/examples/ipfs-101-deno/index.ts
@@ -1,0 +1,33 @@
+import { createRequire } from "https://deno.land/std@0.102.0/node/module.ts";
+
+// import.meta.url will be the location of "this" module (like `__filename` in
+// Node.js), and then serve as the root for your "package", where the
+// `package.json` is expected to be, and where the `node_modules` will be used
+// for resolution of packages.
+const require = createRequire(import.meta.url);
+
+const all = require('it-all')
+const uint8ArrayConcat = require('uint8arrays/concat')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayToString = require('uint8arrays/to-string')
+const IPFS = require("ipfs");
+
+async function main () {
+  const node = await IPFS.create()
+  const version = await node.version()
+
+  console.log('Version:', version.version)
+
+  const file = await node.add({
+    path: 'hello.txt',
+    content: uint8ArrayFromString('Hello World 101')
+  })
+
+  console.log('Added file:', file.path, file.cid.toString())
+
+  const data = uint8ArrayConcat(await all(node.cat(file.cid)))
+
+  console.log('Added file contents:', uint8ArrayToString(data))
+}
+
+main()

--- a/examples/ipfs-101-deno/jspm.ts
+++ b/examples/ipfs-101-deno/jspm.ts
@@ -1,0 +1,27 @@
+'use strict'
+
+import all from 'https://dev.jspm.io/it-all'
+import uint8ArrayConcat from 'https://dev.jspm.io/uint8arrays/concat'
+import uint8ArrayFromString from 'https://dev.jspm.io/uint8arrays/from-string'
+import uint8ArrayToString from 'https://dev.jspm.io/uint8arrays/to-string'
+import IPFS from 'https://dev.jspm.io/ipfs'
+
+async function main () {
+  const node = await IPFS.create()
+  const version = await node.version()
+
+  console.log('Version:', version.version)
+
+  const file = await node.add({
+    path: 'hello.txt',
+    content: uint8ArrayFromString('Hello World 101')
+  })
+
+  console.log('Added file:', file.path, file.cid.toString())
+
+  const data = uint8ArrayConcat(await all(node.cat(file.cid)))
+
+  console.log('Added file contents:', uint8ArrayToString(data))
+}
+
+main()

--- a/examples/ipfs-101-deno/package.json
+++ b/examples/ipfs-101-deno/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "example-ipfs-101-deno",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Using ipfs with deno",
+  "license": "MIT",
+  "scripts": {
+    "clean": "echo 'Nothing to clean...'",
+    "start": "deno run --allow-read=node_modules --unstable --allow-env index.ts",
+    "serve": "npm run start",
+    "test:example": "node tests/test.js"
+  },
+  "devDependencies": {
+    "test-util-ipfs-example": "^1.0.2"
+  },
+  "dependencies": {
+    "ipfs": "^0.56.0",
+    "it-all": "^1.0.4",
+    "uint8arrays": "^2.1.6"
+  }
+}

--- a/examples/ipfs-101-deno/tests/test.js
+++ b/examples/ipfs-101-deno/tests/test.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { node } = require('test-util-ipfs-example');
+const path = require('path')
+
+async function test () {
+  await node.waitForOutput('Added file contents: Hello World 101', 'node', [path.resolve(__dirname, '../index.js')])
+  await node.waitForOutput('Added file contents: Hello World 101', 'node', [path.resolve(__dirname, '../jspm.js')])
+}
+
+test();

--- a/examples/ipfs-101/package.json
+++ b/examples/ipfs-101/package.json
@@ -5,7 +5,7 @@
   "description": "this package.json needs to exist because of new npm config https://github.com/ipfs/js-ipfs/issues/977#issuecomment-326741092",
   "license": "MIT",
   "author": "David Dias <daviddias@ipfs.io>",
-  "main": "1.js",
+  "main": "index.js",
   "scripts": {
     "clean": "echo 'Nothing to clean...'",
     "start": "node index.js",


### PR DESCRIPTION
This PR is a WIP example of running IPFS using Deno.

Since js-ipfs uses CommonJS and Deno uses ESModule it is possible to have some compatibility with Node.JS but not every builtin is implemented and some are partly.

# The std/node library

The std/node part of the Deno standard library is a Node.js compatibility layer. It's primary focus is providing "polyfills" for Node.js's built-in modules. It also provides a mechanism for loading CommonJS modules into Deno.

The library is most useful when trying to use your own or private code that was written for Node.js. If you are trying to consume public npm packages, you are likely to get a better result using a CDN.

Copied from [Deno](https://deno.land/manual@v1.12.1/npm_nodejs/std_node)

When using this method, it throws the following error:

```
> example-ipfs-101-deno@1.0.0 start
> deno run --allow-read=node_modules --unstable --allow-env index.ts

error: Uncaught TypeError: Cannot read property 'RSA_PKCS1_PADDING' of undefined
const padding = crypto.constants.RSA_PKCS1_PADDING
                                 ^
    at Object.<anonymous> (file:///Users/oliveriosousa/Projects/PL/js-ipfs-examples/examples/ipfs-101-deno/node_modules/libp2p-crypto/src/keys/rsa.js:75:34)
    at Module._compile (https://deno.land/std@0.102.0/node/module.ts:168:36)
    at Object.Module._extensions..js (https://deno.land/std@0.102.0/node/module.ts:1123:10)
    at Module.load (https://deno.land/std@0.102.0/node/module.ts:147:34)
    at Function._load (https://deno.land/std@0.102.0/node/module.ts:413:14)
    at Module.require (https://deno.land/std@0.102.0/node/module.ts:133:21)
    at require (https://deno.land/std@0.102.0/node/module.ts:1172:16)
    at Object.<anonymous> (file:///Users/oliveriosousa/Projects/PL/js-ipfs-examples/examples/ipfs-101-deno/node_modules/libp2p-crypto/src/keys/rsa-class.js:12:16)
    at Module._compile (https://deno.land/std@0.102.0/node/module.ts:168:36)
    at Object.Module._extensions..js (https://deno.land/std@0.102.0/node/module.ts:1123:10)
```

# Alternative 

It is possible to also use [JSPM](https://jspm.io/) which will convert NPM modules to ES Modules

When using this method, it throws the following error:

`Import 'https://dev.jspm.io/npm:ipns@0.13.2/src/index.dew.js' failed: 500 Internal Server Error`
