### PR TITLE
chore: make ipfs get output tarballs

### DIFF
--- a/examples/browser-ipns-publish/package.json
+++ b/examples/browser-ipns-publish/package.json
@@ -38,7 +38,7 @@
     "delay": "^5.0.0",
     "execa": "^5.0.0",
     "go-ipfs": "0.8.0",
-    "ipfsd-ctl": "^9.0.0",
+    "ipfsd-ctl": "^10.0.3",
     "parcel": "latest",
     "playwright": "^1.12.3",
     "rimraf": "^3.0.2"

--- a/lib/test-util-ipfs-example/package.json
+++ b/lib/test-util-ipfs-example/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "execa": "^5.1.1",
     "fs-extra": "^9.1.0",
-    "ipfsd-ctl": "^9.0.0",
+    "ipfsd-ctl": "^10.0.3",
     "polka": "^0.5.2",
     "sirv": "^1.0.12",
     "stoppable": "^1.1.0",


### PR DESCRIPTION
`ipfs get` on the cli writes files/folders to disk, also tarballs
and gzipped tarballs. Also gzipped individual files.

In the API it's very similar to `ipfs.ls`. Make it more like the
cli so there's a clear reason to use one or the other.

Also adds types to `interface-ipfs-core` to better catch broken
types in `ipfs-core-types`.

BREAKING CHANGE: the output type of `ipfs.get` has changed and the `recursive` option has been removed from `ipfs.ls` since it was not supported everywhere

This PR was cherry pick from https://github.com/ipfs/js-ipfs/pull/3785

CC @hugomrdias