### PR TITLE
fix: detect ed25519 keys in ws test

### DIFF
--- a/examples/browser-exchange-files/tests/test.js
+++ b/examples/browser-exchange-files/tests/test.js
@@ -114,7 +114,7 @@ play.describe('upload file using http client: ', () => {
     const id = await daemon.api.id()
     const IPFS_RELAY_ADDRESS = id.addresses
       .map(ma => ma.toString())
-      .find(addr => addr.includes('/ws/p2p'))
+      .find(addr => addr.includes('/ws/p2p/'))
 
 
     const pageOnePeerId = (await pageOne.textContent(nodeId)).trim()

--- a/examples/circuit-relaying/tests/test.js
+++ b/examples/circuit-relaying/tests/test.js
@@ -108,7 +108,7 @@ play.describe('http client pubsub:', () => {
 
     const IPFS_RELAY_ADDRESS = id.addresses
       .map(ma => ma.toString())
-      .find(addr => addr.includes('/ws/p2p/Qm'))
+      .find(addr => addr.includes('/ws/p2p/'))
     const IPFS_RELAY_ID = id.id
 
     const pageOnePeerId = await subscribe(pageOne, IPFS_RELAY_ADDRESS, IPFS_RELAY_ID)


### PR DESCRIPTION
Relax test to just look for `/ws/p2p/` string

This PR was cherry pick from https://github.com/ipfs/js-ipfs/commit/7a920d85019682ea36872d889e53850353be4cee

CC @hugomrdias