### PR TITLE
fix: add missing dependencies

### DIFF
--- a/examples/custom-ipfs-repo/package.json
+++ b/examples/custom-ipfs-repo/package.json
@@ -19,7 +19,8 @@
     "ipfs": "^0.58.1",
     "ipfs-repo": "^11.0.1",
     "it-all": "^1.0.4",
-    "multiformats": "^9.4.1"
+    "multiformats": "^9.4.1",
+    "uint8arrays": "^2.1.6"
   },
   "devDependencies": {
     "test-util-ipfs-example": "^1.0.2"

--- a/examples/custom-libp2p/package.json
+++ b/examples/custom-libp2p/package.json
@@ -19,7 +19,8 @@
     "libp2p-kad-dht": "^0.23.1",
     "libp2p-mdns": "^0.17.0",
     "libp2p-mplex": "^0.10.2",
-    "libp2p-tcp": "^0.17.1"
+    "libp2p-tcp": "^0.17.1",
+    "uint8arrays": "^2.1.6"
   },
   "devDependencies": {
     "test-util-ipfs-example": "^1.0.2"


### PR DESCRIPTION
- Adds missing dependencies

NOTE: It works when using workspaces because some package depends on the missing lib.
