### PR TITLE
chore: npm7 compat for browser-vue example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,6 @@ bundle.js
 tsconfig-types.aegir.json
 .tsbuildinfo
 
-# Deployment files
-.npmrc
-
 # Editor files
 .idea
 .vscode

--- a/examples/browser-vue/.npmrc
+++ b/examples/browser-vue/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
The peer deps of `@vue/cli-plugin-*` cause npm7 to spin endlessly on install.

Use a `.npmrc` file to use the npm6 peer dep behaviour to fix this.