### PR TITLE
fix: add missing test-util-ipfs-example deps

### DIFF
--- a/examples/browser-angular/package.json
+++ b/examples/browser-angular/package.json
@@ -43,6 +43,7 @@
     "node-polyfill-webpack-plugin": "^1.1.4",
     "playwright": "^1.12.3",
     "rimraf": "^3.0.2",
+    "test-util-ipfs-example": "^1.0.2",
     "typescript": "~4.3.5"
   }
 }

--- a/examples/browser-ipns-publish/package.json
+++ b/examples/browser-ipns-publish/package.json
@@ -41,6 +41,7 @@
     "ipfsd-ctl": "^10.0.3",
     "parcel": "latest",
     "playwright": "^1.12.3",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "test-util-ipfs-example": "^1.0.2"
   }
 }


### PR DESCRIPTION
A couple of the examples were missing the `test-util-ipfs-example` dep.