### PR TITLE
fix: add missing deps

### DIFF
--- a/examples/browser-angular/package.json
+++ b/examples/browser-angular/package.json
@@ -22,6 +22,7 @@
     "@angular/router": "~12.2.0",
     "global": "^4.4.0",
     "ipfs": "^0.58.1",
+    "ipfs-core-types": "^0.7.1",
     "rxjs": "~6.6.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"


### PR DESCRIPTION
This is depended on directly but isn't in the package.json

Annoyingly it works in CI by accident as the example also depends on `ipfs` which depends on `ipfs-core-types` as a dep.