### PR TITLE
fix: add CI actions to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Contributions are what make the open source community such an amazing place to b
 - Follow the [example-template](`https://github.com/ipfs-examples/example-template`)
   - This repository serves as template to create new examples to guarantee consistency between examples. It contains all the necessary files to create a new example
 
-- Follow the [example-template-for-&-go](`https://github.com/ipfs-examples/example-fork-go-template`)
+- Follow the [example-template-fork-&-go](`https://github.com/ipfs-examples/example-fork-go-template`)
   - This repository serves as template to be used as a reference of how to implement the CI in order to sync the example with a standalone repo (correspondent to each example)
 
 - Examples must:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Contributions are what make the open source community such an amazing place to b
 - Follow the [example-template](`https://github.com/ipfs-examples/example-template`)
   - This repository serves as template to create new examples to guarantee consistency between examples. It contains all the necessary files to create a new example
 
+- Follow the [example-template-for-&-go](`https://github.com/ipfs-examples/example-fork-go-template`)
+  - This repository serves as template to be used as a reference of how to implement the CI in order to sync the example with a standalone repo (correspondent to each example)
+
 - Examples must:
   - Live inside the `/examples/` folder
   - Have tests and should make use of `test-util-ipfs-example` library

--- a/examples/browser-add-readable-stream/.github/pull_request_template.md
+++ b/examples/browser-add-readable-stream/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-add-readable-stream/.github/pull_request_template.md
+++ b/examples/browser-add-readable-stream/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-add-readable-stream/.github/workflows/sync.yml
+++ b/examples/browser-add-readable-stream/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-add-readable-stream"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-angular/.github/pull_request_template.md
+++ b/examples/browser-angular/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-angular/.github/pull_request_template.md
+++ b/examples/browser-angular/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-angular/.github/workflows/sync.yml
+++ b/examples/browser-angular/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-angular"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-browserify/.github/pull_request_template.md
+++ b/examples/browser-browserify/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-browserify/.github/pull_request_template.md
+++ b/examples/browser-browserify/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-browserify/.github/workflows/sync.yml
+++ b/examples/browser-browserify/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-browserify"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-create-react-app/.github/pull_request_template.md
+++ b/examples/browser-create-react-app/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-create-react-app/.github/pull_request_template.md
+++ b/examples/browser-create-react-app/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-create-react-app/.github/workflows/sync.yml
+++ b/examples/browser-create-react-app/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-create-react-app"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-exchange-files/.github/pull_request_template.md
+++ b/examples/browser-exchange-files/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-exchange-files/.github/pull_request_template.md
+++ b/examples/browser-exchange-files/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-exchange-files/.github/workflows/sync.yml
+++ b/examples/browser-exchange-files/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-exchange-files"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-ipns-publish/.github/pull_request_template.md
+++ b/examples/browser-ipns-publish/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-ipns-publish/.github/pull_request_template.md
+++ b/examples/browser-ipns-publish/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-ipns-publish/.github/workflows/sync.yml
+++ b/examples/browser-ipns-publish/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-ipns-publish"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-lit/.github/pull_request_template.md
+++ b/examples/browser-lit/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-lit/.github/pull_request_template.md
+++ b/examples/browser-lit/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-lit/.github/workflows/sync.yml
+++ b/examples/browser-lit/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-lit"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-mfs/.github/pull_request_template.md
+++ b/examples/browser-mfs/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-mfs/.github/pull_request_template.md
+++ b/examples/browser-mfs/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-mfs/.github/workflows/sync.yml
+++ b/examples/browser-mfs/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-mfs"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-nextjs/.github/pull_request_template.md
+++ b/examples/browser-nextjs/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-nextjs/.github/pull_request_template.md
+++ b/examples/browser-nextjs/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-nextjs/.github/workflows/sync.yml
+++ b/examples/browser-nextjs/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-nextjs"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-parceljs/.github/pull_request_template.md
+++ b/examples/browser-parceljs/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-parceljs/.github/pull_request_template.md
+++ b/examples/browser-parceljs/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-parceljs/.github/workflows/sync.yml
+++ b/examples/browser-parceljs/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-parceljs"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-readablestream/.github/pull_request_template.md
+++ b/examples/browser-readablestream/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-readablestream/.github/pull_request_template.md
+++ b/examples/browser-readablestream/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-readablestream/.github/workflows/sync.yml
+++ b/examples/browser-readablestream/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-readablestream"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-script-tag/.github/pull_request_template.md
+++ b/examples/browser-script-tag/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-script-tag/.github/pull_request_template.md
+++ b/examples/browser-script-tag/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-script-tag/.github/workflows/sync.yml
+++ b/examples/browser-script-tag/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-script-tag"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-service-worker/.github/pull_request_template.md
+++ b/examples/browser-service-worker/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-service-worker/.github/pull_request_template.md
+++ b/examples/browser-service-worker/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-service-worker/.github/workflows/sync.yml
+++ b/examples/browser-service-worker/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-service-worker"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-sharing-node-across-tabs/.github/pull_request_template.md
+++ b/examples/browser-sharing-node-across-tabs/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-sharing-node-across-tabs/.github/pull_request_template.md
+++ b/examples/browser-sharing-node-across-tabs/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-sharing-node-across-tabs/.github/workflows/sync.yml
+++ b/examples/browser-sharing-node-across-tabs/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-sharing-node-across-tabs"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-video-streaming/.github/pull_request_template.md
+++ b/examples/browser-video-streaming/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-video-streaming/.github/pull_request_template.md
+++ b/examples/browser-video-streaming/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-video-streaming/.github/workflows/sync.yml
+++ b/examples/browser-video-streaming/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-video-streaming"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-vue/.github/pull_request_template.md
+++ b/examples/browser-vue/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-vue/.github/pull_request_template.md
+++ b/examples/browser-vue/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-vue/.github/workflows/sync.yml
+++ b/examples/browser-vue/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-vue"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/browser-webpack/.github/pull_request_template.md
+++ b/examples/browser-webpack/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/browser-webpack/.github/pull_request_template.md
+++ b/examples/browser-webpack/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/browser-webpack/.github/workflows/sync.yml
+++ b/examples/browser-webpack/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/browser-webpack"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/circuit-relaying/.github/pull_request_template.md
+++ b/examples/circuit-relaying/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/circuit-relaying/.github/pull_request_template.md
+++ b/examples/circuit-relaying/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/circuit-relaying/.github/workflows/sync.yml
+++ b/examples/circuit-relaying/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/circuit-relaying"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/custom-ipfs-repo/.github/pull_request_template.md
+++ b/examples/custom-ipfs-repo/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/custom-ipfs-repo/.github/pull_request_template.md
+++ b/examples/custom-ipfs-repo/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/custom-ipfs-repo/.github/workflows/sync.yml
+++ b/examples/custom-ipfs-repo/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/custom-ipfs-repo"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/custom-ipld-formats/.github/pull_request_template.md
+++ b/examples/custom-ipld-formats/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/custom-ipld-formats/.github/pull_request_template.md
+++ b/examples/custom-ipld-formats/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/custom-ipld-formats/.github/workflows/sync.yml
+++ b/examples/custom-ipld-formats/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/custom-ipld-formats"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/custom-libp2p/.github/pull_request_template.md
+++ b/examples/custom-libp2p/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/custom-libp2p/.github/pull_request_template.md
+++ b/examples/custom-libp2p/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/custom-libp2p/.github/workflows/sync.yml
+++ b/examples/custom-libp2p/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/custom-libp2p"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/http-client-browser-pubsub/.github/pull_request_template.md
+++ b/examples/http-client-browser-pubsub/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/http-client-browser-pubsub/.github/pull_request_template.md
+++ b/examples/http-client-browser-pubsub/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/http-client-browser-pubsub/.github/workflows/sync.yml
+++ b/examples/http-client-browser-pubsub/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/http-client-browser-pubsub"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/http-client-bundle-webpack/.github/pull_request_template.md
+++ b/examples/http-client-bundle-webpack/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/http-client-bundle-webpack/.github/pull_request_template.md
+++ b/examples/http-client-bundle-webpack/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/http-client-bundle-webpack/.github/workflows/sync.yml
+++ b/examples/http-client-bundle-webpack/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/http-client-bundle-webpack"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/http-client-name-api/.github/pull_request_template.md
+++ b/examples/http-client-name-api/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/http-client-name-api/.github/pull_request_template.md
+++ b/examples/http-client-name-api/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/http-client-name-api/.github/workflows/sync.yml
+++ b/examples/http-client-name-api/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/http-client-name-api"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/http-client-upload-file/.github/pull_request_template.md
+++ b/examples/http-client-upload-file/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/http-client-upload-file/.github/pull_request_template.md
+++ b/examples/http-client-upload-file/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/http-client-upload-file/.github/workflows/sync.yml
+++ b/examples/http-client-upload-file/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/http-client-upload-file"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/ipfs-101/.github/pull_request_template.md
+++ b/examples/ipfs-101/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/ipfs-101/.github/pull_request_template.md
+++ b/examples/ipfs-101/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/ipfs-101/.github/workflows/sync.yml
+++ b/examples/ipfs-101/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/ipfs-101"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/ipfs-client-add-files/.github/pull_request_template.md
+++ b/examples/ipfs-client-add-files/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/ipfs-client-add-files/.github/pull_request_template.md
+++ b/examples/ipfs-client-add-files/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/ipfs-client-add-files/.github/workflows/sync.yml
+++ b/examples/ipfs-client-add-files/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/ipfs-client-add-files"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/run-in-electron/.github/pull_request_template.md
+++ b/examples/run-in-electron/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/run-in-electron/.github/pull_request_template.md
+++ b/examples/run-in-electron/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/run-in-electron/.github/workflows/sync.yml
+++ b/examples/run-in-electron/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/run-in-electron"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/running-multiple-nodes/.github/pull_request_template.md
+++ b/examples/running-multiple-nodes/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/running-multiple-nodes/.github/pull_request_template.md
+++ b/examples/running-multiple-nodes/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/running-multiple-nodes/.github/workflows/sync.yml
+++ b/examples/running-multiple-nodes/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/running-multiple-nodes"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/traverse-ipld-graphs/.github/pull_request_template.md
+++ b/examples/traverse-ipld-graphs/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/traverse-ipld-graphs/.github/pull_request_template.md
+++ b/examples/traverse-ipld-graphs/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/traverse-ipld-graphs/.github/workflows/sync.yml
+++ b/examples/traverse-ipld-graphs/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/traverse-ipld-graphs"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/types-use-ipfs-from-ts/.github/pull_request_template.md
+++ b/examples/types-use-ipfs-from-ts/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/types-use-ipfs-from-ts/.github/pull_request_template.md
+++ b/examples/types-use-ipfs-from-ts/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/types-use-ipfs-from-ts/.github/workflows/sync.yml
+++ b/examples/types-use-ipfs-from-ts/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/types-use-ipfs-from-ts"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com

--- a/examples/types-use-ipfs-from-typed-js/.github/pull_request_template.md
+++ b/examples/types-use-ipfs-from-typed-js/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 **IMPORTANT: Please do not create a Pull Request for this repository.**
 
+The contents of this repository are automatically synced from the parent [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples) so any changes made to the standalone repository will be lost after the next sync.
+
+Please open a PR against [IPFS Examples](https://github.com/ipfs-examples/js-ipfs-examples) instead.
+
 ## Contributing
 
 Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.

--- a/examples/types-use-ipfs-from-typed-js/.github/pull_request_template.md
+++ b/examples/types-use-ipfs-from-typed-js/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+**IMPORTANT: Please do not create a Pull Request for this repository.**
+
+## Contributing
+
+Contributions are what make the open source community such an amazing place to be learn, inspire, and create. Any contributions you make are **greatly appreciated**.
+
+1. Fork the [IPFS Examples Project](https://github.com/ipfs-examples/js-ipfs-examples)
+2. Create your Feature Branch (`git checkout -b feature/amazing-example`)
+3. Commit your Changes (`git commit -a -m 'feat: add some amazing example'`)
+4. Push to the Branch (`git push origin feature/amazing-example`)
+5. Open a Pull Request

--- a/examples/types-use-ipfs-from-typed-js/.github/workflows/sync.yml
+++ b/examples/types-use-ipfs-from-typed-js/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+name: Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull from another repository
+        uses: ipfs-examples/actions-pull-directory-from-repo@main
+        with:
+          source-repo: "ipfs-examples/js-ipfs-examples"
+          source-folder-path: "examples/types-use-ipfs-from-typed-js"
+          source-branch: "master"
+          target-branch: "main"
+          git-username: github-actions
+          git-email: github-actions@github.com


### PR DESCRIPTION
- Adds CI actions to all examples

This way the examples are copied as is to the standalone.
If this PR is approved it still needs to sync the first time with all examples to have this changes reflected.

Fixes https://github.com/ipfs-examples/js-ipfs-examples/issues/44

cc @achingbrain 