### PR TITLE
chore: add missing dep

### DIFF
--- a/examples/types-use-ipfs-from-typed-js/package.json
+++ b/examples/types-use-ipfs-from-typed-js/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "multiformats": "^9.4.1",
+    "ipfs-core-types": "^0.8.0",
     "typescript": "4.3.5"
   }
 }


### PR DESCRIPTION
`ipfs-core-types` dep was missing.