### PR TITLE
chore: upgrade webrtc-star

### DIFF
--- a/examples/browser-exchange-files/README.md
+++ b/examples/browser-exchange-files/README.md
@@ -36,7 +36,7 @@
   - [4. Dial to a node using WebSockets (your desktop ones)](#4-dial-to-a-node-using-websockets-your-desktop-ones)
   - [5. Transfer files between all of your nodes!](#5-transfer-files-between-all-of-your-nodes)
 - [Going to production?](#going-to-production)
-  - [Use your own `libp2p-webrtc-star` signaling server](#use-your-own-libp2p-webrtc-star-signaling-server)
+  - [Use your own `libp2p-webrtc-star` signalling server](#use-your-own-libp2p-webrtc-star-signalling-server)
 - [References](#references)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
@@ -101,7 +101,7 @@ Here's what we are going to be doing:
 
 1. Install a `go-ipfs` or `js-ipfs` node in your machine
 2. Make your daemons listen on WebSockets
-3. Start a `libp2p-webrtc-star` signaling server
+3. Start a `libp2p-webrtc-star` signalling server
 4. Start the app
 5. Dial to a node using WebSockets (your desktop ones)
 6. Transfer files between all of your nodes!
@@ -267,17 +267,17 @@ _For more examples, please refer to the [Documentation](#documentation)_
 
 This example uses public webrtc-star servers. These servers should be used for experimenting and demos, they **MUST** not be used in production as there is no guarantee on availability.
 
-### Use your own `libp2p-webrtc-star` signaling server
+### Use your own `libp2p-webrtc-star` signalling server
 
 This server allows the two browser nodes to talk to each other by doing the initial handshake and network introductions.
 
-First install the `libp2p-webrtc-star` module globally:
+First install the `libp2p-webrtc-star-signalling-server` module globally:
 
 ```sh
-> npm install -g libp2p-webrtc-star
+> npm install -g libp2p-webrtc-star-signalling-server
 ```
 
-This will give you the `webrtc-star` command. Use this to start a signaling server:
+This will give you the `webrtc-star` command. Use this to start a signalling server:
 
 ```sh
 > webrtc-star
@@ -285,7 +285,7 @@ This will give you the `webrtc-star` command. Use this to start a signaling serv
 
 By default it will listen to all incoming connections on port 13579. Override this with the `--host` and/or `--port` options. That is, the following multiaddr: `/ip4/127.0.0.1/tcp/13579/wss/p2p-webrtc-star`.
 
-You should add your signaling server in the IPFS config swarm addresses, so that you listen for new connections through it.
+You should add your signalling server in the IPFS config swarm addresses, so that you listen for new connections through it.
 
 ## References
 

--- a/examples/browser-exchange-files/package.json
+++ b/examples/browser-exchange-files/package.json
@@ -23,7 +23,7 @@
     "ipfs": "^0.59.0",
     "ipfs-core-types": "^0.8.0",
     "ipfs-http-client": "^53.0.0",
-    "libp2p-webrtc-star": "^0.23.0",
+    "libp2p-webrtc-star-signalling-server": "^0.1.0",
     "parcel": "latest",
     "playwright": "^1.12.3",
     "rimraf": "^3.0.2",

--- a/examples/browser-exchange-files/tests/test.js
+++ b/examples/browser-exchange-files/tests/test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const webRTCStarSigServer = require('libp2p-webrtc-star/src/sig-server')
+const webRTCStarSigServer = require('libp2p-webrtc-star-signalling-server')
 
 const { test, expect } = require('@playwright/test');
 const { playwright } = require('test-util-ipfs-example');


### PR DESCRIPTION
The signalling server has been split out of the `libp2p-webrtc-star` module into it's own, so refactor the tests to use that and update the docs.