### PR TITLE
fix: do not transform exponentiation operator

### DIFF
--- a/examples/browser-create-react-app/package.json
+++ b/examples/browser-create-react-app/package.json
@@ -15,6 +15,8 @@
   "browserslist": {
     "production": [
       ">0.2%",
+      "not ie <= 99",
+      "not android <= 4.4.4",
       "not dead",
       "not op_mini all"
     ],


### PR DESCRIPTION
The `babel-plugin-transform-exponentiation-operator ` Babel plugin transforms `1n ** 1n` into `Math.pow(1n, 1n)` which doesn't work because `Math.pow` doesn't support BigInts - https://github.com/facebook/create-react-app/issues/6907#issuecomment-778178677

This is used in `@noble/ed25519` which recently got added to `libp2p-crypto` - https://github.com/libp2p/js-libp2p-crypto/pull/202

The fix is to change the `"browsersList"` setting to exclude ie and old android - https://github.com/blockstack/stacks.js/issues/1096#issuecomment-946350299