### PR TITLE
fix: do not use ipfs-daemon@next

### DIFF
--- a/examples/custom-ipld-formats/package.json
+++ b/examples/custom-ipld-formats/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "dag-jose": "^1.0.0",
     "ipfs-core": "^0.11.0",
-    "ipfs-daemon": "next",
+    "ipfs-daemon": "^0.10.4",
     "ipfs-http-client": "^53.0.0",
     "multiformats": "^9.4.1",
     "uint8arrays": "^3.0.0"


### PR DESCRIPTION
It pulls in the dag-json changes so the CIDs are different.