### PR TITLE
fix: simplify ts example

### DIFF
--- a/examples/types-use-ipfs-from-ts/package.json
+++ b/examples/types-use-ipfs-from-ts/package.json
@@ -8,8 +8,7 @@
     "test": "tsc --noEmit"
   },
   "dependencies": {
-    "ipfs-core": "^0.14.0",
-    "multiformats": "^9.4.1"
+    "ipfs-core": "^0.14.0"
   },
   "devDependencies": {
     "typescript": "^4.5.5"

--- a/examples/types-use-ipfs-from-ts/src/main.ts
+++ b/examples/types-use-ipfs-from-ts/src/main.ts
@@ -1,5 +1,5 @@
 import { IPFS, create } from 'ipfs-core'
-import { CID } from 'multiformats/cid'
+import type { CID } from 'ipfs-core'
 
 export default async function main() {
   const node = await create()


### PR DESCRIPTION
If we import the CID type from ipfs-core we don't need the extra
multiformats dep.