### PR TITLE
fix: remove extra deps

### DIFF
--- a/examples/types-use-ipfs-from-typed-js/package.json
+++ b/examples/types-use-ipfs-from-typed-js/package.json
@@ -11,8 +11,6 @@
     "ipfs-core": "^0.14.0"
   },
   "devDependencies": {
-    "multiformats": "^9.4.1",
-    "ipfs-core-types": "^0.10.0",
     "typescript": "^4.5.5"
   }
 }

--- a/examples/types-use-ipfs-from-typed-js/src/main.js
+++ b/examples/types-use-ipfs-from-typed-js/src/main.js
@@ -1,7 +1,8 @@
 const { create } = require('ipfs-core')
+
 /**
- * @typedef {import('ipfs-core-types').IPFS} IPFS
- * @typedef {import('multiformats/cid').CID} CID
+ * @typedef {import('ipfs-core').IPFS} IPFS
+ * @typedef {import('ipfs-core').CID} CID
  */
 
 async function main () {


### PR DESCRIPTION
All types needed for the example can be found in the `ipfs-core` package.