### PR TITLE
fix: add process and util dev deps to parcel projects

### DIFF
--- a/examples/browser-add-readable-stream/package.json
+++ b/examples/browser-add-readable-stream/package.json
@@ -19,9 +19,11 @@
   "devDependencies": {
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/browser-exchange-files/package.json
+++ b/examples/browser-exchange-files/package.json
@@ -24,9 +24,11 @@
     "ipfs-core-types": "^0.10.0",
     "ipfs-http-client": "^56.0.0",
     "libp2p-webrtc-star-signalling-server": "^0.1.0",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/browser-ipns-publish/package.json
+++ b/examples/browser-ipns-publish/package.json
@@ -39,9 +39,11 @@
     "execa": "^6.0.0",
     "go-ipfs": "^0.11.0",
     "ipfsd-ctl": "^10.0.3",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/browser-lit/package.json
+++ b/examples/browser-lit/package.json
@@ -22,9 +22,11 @@
   "devDependencies": {
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/browser-mfs/package.json
+++ b/examples/browser-mfs/package.json
@@ -20,9 +20,11 @@
   "devDependencies": {
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/browser-parceljs/package.json
+++ b/examples/browser-parceljs/package.json
@@ -20,9 +20,11 @@
   "devDependencies": {
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/browser-readablestream/package.json
+++ b/examples/browser-readablestream/package.json
@@ -21,9 +21,11 @@
   "devDependencies": {
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/browser-script-tag/package.json
+++ b/examples/browser-script-tag/package.json
@@ -16,9 +16,11 @@
   "devDependencies": {
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/browser-sharing-node-across-tabs/package.json
+++ b/examples/browser-sharing-node-across-tabs/package.json
@@ -21,9 +21,11 @@
   "devDependencies": {
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/browser-video-streaming/package.json
+++ b/examples/browser-video-streaming/package.json
@@ -21,9 +21,11 @@
   "devDependencies": {
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/circuit-relaying/package.json
+++ b/examples/circuit-relaying/package.json
@@ -27,9 +27,11 @@
     "@playwright/test": "^1.12.3",
     "fs-extra": "^10.0.0",
     "ipfs-http-client": "^56.0.0",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/http-client-browser-pubsub/package.json
+++ b/examples/http-client-browser-pubsub/package.json
@@ -21,9 +21,11 @@
     "@playwright/test": "^1.12.3",
     "go-ipfs": "^0.11.0",
     "ipfs": "^0.62.0",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/http-client-name-api/package.json
+++ b/examples/http-client-name-api/package.json
@@ -20,9 +20,11 @@
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
     "go-ipfs": "^0.11.0",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/http-client-upload-file/package.json
+++ b/examples/http-client-upload-file/package.json
@@ -25,9 +25,11 @@
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
     "ipfs": "^0.62.0",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }

--- a/examples/ipfs-client-add-files/package.json
+++ b/examples/ipfs-client-add-files/package.json
@@ -18,9 +18,11 @@
     "@babel/core": "^7.14.8",
     "@playwright/test": "^1.12.3",
     "ipfs": "^0.62.0",
-    "parcel": "latest",
+    "parcel": "^2.3.2",
     "playwright": "^1.12.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
-    "test-util-ipfs-example": "^1.0.2"
+    "test-util-ipfs-example": "^1.0.2",
+    "util": "^0.12.4"
   }
 }


### PR DESCRIPTION
In CI parcel runs with `--no-autoinstall` so we need to explicitly depend on node polyfills.