### PR TITLE
Update cli/config options to work with webpack v5

### DIFF
--- a/examples/browser-service-worker/package.json
+++ b/examples/browser-service-worker/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "webpack --env production",
-    "serve": "webpack serve --hot-only --mode=development",
+    "serve": "webpack serve --hot only --mode=development",
     "start": "npm run serve",
     "test": "npm run build && playwright test tests"
   },

--- a/examples/browser-service-worker/src/service.js
+++ b/examples/browser-service-worker/src/service.js
@@ -76,7 +76,7 @@ const fetchViewer = async ({ url }) => {
   const body = new Blob([`<html data-viewer>
 <head>
   <title>${url.pathname}</title>
-  <script src="/main.js"></script>
+  <script src="/main.bundle.js"></script>
 </head>
 <body>
   <iframe id="viewer" style="width:100%;height:100%;position:fixed;top:0;left:0;border:none;" src="/view${url.pathname}"></iframe>

--- a/examples/browser-service-worker/webpack.config.js
+++ b/examples/browser-service-worker/webpack.config.js
@@ -58,7 +58,7 @@ const dev = {
   // Spin up a server for quick development
   devServer: {
     historyApiFallback: true,
-    contentBase: paths.build,
+    static: paths.build,
     open: true,
     compress: true,
     hot: true,

--- a/examples/browser-webpack/package.json
+++ b/examples/browser-webpack/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "webpack --env production",
-    "serve": "webpack serve --hot-only --mode=development",
+    "serve": "webpack serve --hot only --mode=development",
     "start": "npm run serve",
     "test": "npm run build && playwright test tests"
   },

--- a/examples/browser-webpack/webpack.config.js
+++ b/examples/browser-webpack/webpack.config.js
@@ -59,7 +59,7 @@ const dev = {
   // Spin up a server for quick development
   devServer: {
     historyApiFallback: true,
-    contentBase: paths.build,
+    static: paths.build,
     open: true,
     compress: true,
     hot: true,

--- a/examples/http-client-bundle-webpack/package.json
+++ b/examples/http-client-bundle-webpack/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "webpack --env production",
-    "serve": "webpack serve --hot-only --mode=development",
+    "serve": "webpack serve --hot only --mode=development",
     "start": "npm run serve",
     "test": "npm run build && playwright test tests"
   },

--- a/examples/http-client-bundle-webpack/webpack.config.js
+++ b/examples/http-client-bundle-webpack/webpack.config.js
@@ -59,7 +59,7 @@ const dev = {
   // Spin up a server for quick development
   devServer: {
     historyApiFallback: true,
-    contentBase: paths.build,
+    static: paths.build,
     open: true,
     compress: true,
     hot: true,


### PR DESCRIPTION
Webpack was upgraded to v5 but the options were still in v4. Also fixed the js script tag url.