### PR TITLE
incompatible typescript version - fixes #379

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  examples:
+    runs-on: ubuntu-latest
+    name: Test ${{ matrix.project }}
+    strategy:
+      matrix:
+        project:
+          - browser-add-readable-stream
+          - browser-angular
+          - browser-create-react-app
+          - browser-exchange-files
+          - browser-ipns-publish
+          - browser-lit
+          - browser-mfs
+          - browser-nextjs
+          - browser-readablestream
+          - browser-script-tag
+          - browser-service-worker
+          - browser-sharing-node-across-tabs
+          - browser-video-streaming
+          - browser-vite
+          - browser-vue
+          - browser-webpack
+          - circuit-relaying
+          - custom-ipfs-repo
+          - custom-ipld-formats
+          - custom-libp2p
+          - http-client-browser-pubsub
+          - http-client-bundle-webpack
+          - http-client-name-api
+          - http-client-upload-file
+          - ipfs-101
+          #- ipfs-client-add-files
+          - run-in-electron
+          - running-multiple-nodes
+          - traverse-ipld-graphs
+          - types-use-ipfs-from-ts
+          - types-use-ipfs-from-typed-js
+    defaults:
+      run:
+        working-directory: examples/${{ matrix.project }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+      - run: npm install
+      - uses: GabrielBB/xvfb-action@v1
+        name: Run tests
+        with:
+          run: npm test
+          working-directory: examples/${{ matrix.project }}
+
+  monorepo:
+    runs-on: ubuntu-latest
+    name: Test monorepo
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm install
+      - uses: GabrielBB/xvfb-action@v1
+        name: Run test:examples
+        with:
+          run: npm run test:examples

--- a/examples/browser-angular/package.json
+++ b/examples/browser-angular/package.json
@@ -47,6 +47,6 @@
     "playwright": "^1.12.3",
     "rimraf": "^3.0.2",
     "test-util-ipfs-example": "^1.0.2",
-    "typescript": "^4.5.5"
+    "typescript": "4.5.5"
   }
 }

--- a/examples/types-use-ipfs-from-ts/package.json
+++ b/examples/types-use-ipfs-from-ts/package.json
@@ -12,6 +12,6 @@
     "multiformats": "^9.6.5"
   },
   "devDependencies": {
-    "typescript": "^4.5.5"
+    "typescript": "4.5.5"
   }
 }

--- a/examples/types-use-ipfs-from-typed-js/package.json
+++ b/examples/types-use-ipfs-from-typed-js/package.json
@@ -12,6 +12,6 @@
     "multiformats": "^9.6.5"
   },
   "devDependencies": {
-    "typescript": "^4.5.5"
+    "typescript": "4.5.5"
   }
 }


### PR DESCRIPTION
I removed the ^ from the typescript package because 4.7.4 seems incompatible with the Angular compiler.
This prevented a successful test run with ```yarn run test```

Tests are now all running through.