### PR TITLE
fix: fix electron main reference

### DIFF
--- a/examples/run-in-electron/package.json
+++ b/examples/run-in-electron/package.json
@@ -10,7 +10,7 @@
   ],
   "license": "MIT",
   "author": "David Dias <daviddias@ipfs.io>",
-  "main": "main.cjs",
+  "main": "main.js",
   "scripts": {
     "clean": "echo 'Nothing to clean...'",
     "start": "electron .",


### PR DESCRIPTION
The main module is called `main.js` not `main.cjs`. This prevents `npm start` from working.

![image](https://user-images.githubusercontent.com/5257753/191161366-b57d1b24-860f-45d6-a27a-abe94b971601.png)
