### PR TITLE
feat: use kubo-rpc-client

### DIFF
--- a/examples/browser-ipns-publish/package.json
+++ b/examples/browser-ipns-publish/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@libp2p/websockets": "^3.0.3",
     "ipfs-core": "^0.16.0",
-    "ipfs-http-client": "^58.0.0",
+    "kubo-rpc-client": "^1.0.1",
     "ipfs-utils": "^9.0.6",
     "ipns": "^2.0.3",
     "it-last": "^1.0.4",

--- a/examples/browser-ipns-publish/tests/test.js
+++ b/examples/browser-ipns-publish/tests/test.js
@@ -1,14 +1,14 @@
 import { test, expect } from '@playwright/test'
 import { playwright } from 'test-util-ipfs-example'
 import * as goIpfsModule from 'go-ipfs'
-import * as ipfsHttpModule from 'ipfs-http-client'
+import * as kuboRpcModule from 'kubo-rpc-client'
 
 // Setup
 const play = test.extend({
   ...playwright.servers(),
   ...playwright.daemons(
     {
-      ipfsHttpModule,
+      kuboRpcModule,
       ipfsBin: goIpfsModule.path(),
       args: [
         "--enable-pubsub-experiment",

--- a/examples/http-client-browser-pubsub/package.json
+++ b/examples/http-client-browser-pubsub/package.json
@@ -15,7 +15,8 @@
   },
   "browserslist": "last 1 Chrome version",
   "dependencies": {
-    "ipfs-http-client": "^58.0.0"
+    "ipfs-http-client": "^58.0.0",
+    "kubo-rpc-client": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",

--- a/examples/http-client-browser-pubsub/tests/test.js
+++ b/examples/http-client-browser-pubsub/tests/test.js
@@ -2,6 +2,7 @@ import { test } from '@playwright/test';
 import { playwright } from 'test-util-ipfs-example'
 import * as ipfsModule from 'ipfs'
 import * as ipfsHttpModule from 'ipfs-http-client'
+import * as kuboRpcModule from 'kubo-rpc-client'
 import * as goIpfsModule from 'go-ipfs'
 
 // Setup
@@ -9,14 +10,15 @@ const play = test.extend({
   ...playwright.servers(),
   ...playwright.daemons(
     {
-      ipfsHttpModule,
     },
     {
       js: {
+        ipfsHttpModule,
         ipfsBin: ipfsModule.path()
       },
       go: {
         ipfsBin: goIpfsModule.path(),
+        kuboRpcModule,
         args: ['--enable-pubsub-experiment']
       }
     },

--- a/examples/http-client-name-api/package.json
+++ b/examples/http-client-name-api/package.json
@@ -15,7 +15,7 @@
   },
   "browserslist": "last 1 Chrome version",
   "dependencies": {
-    "ipfs-http-client": "^58.0.0"
+    "kubo-rpc-client": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",

--- a/examples/http-client-name-api/package.json
+++ b/examples/http-client-name-api/package.json
@@ -15,6 +15,7 @@
   },
   "browserslist": "last 1 Chrome version",
   "dependencies": {
+    "ipfs-http-client": "^58.0.0",
     "kubo-rpc-client": "^1.0.1"
   },
   "devDependencies": {

--- a/examples/http-client-name-api/tests/test.js
+++ b/examples/http-client-name-api/tests/test.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { playwright } from 'test-util-ipfs-example';
-import * as ipfsHttpModule from 'ipfs-http-client'
+import * as kuboRpcModule from 'kubo-rpc-client'
 import * as goIpfsModule from 'go-ipfs'
 
 // Setup
@@ -8,7 +8,7 @@ const play = test.extend({
   ...playwright.servers(),
   ...playwright.daemons(
     {
-      ipfsHttpModule,
+      kuboRpcModule,
       ipfsBin: goIpfsModule.path(),
       args: ['--enable-pubsub-experiment']
     },


### PR DESCRIPTION
Tracking issue: https://github.com/ipfs/js-kubo-rpc-client/issues/37
Parent issue: https://github.com/ipfs/js-kubo-rpc-client/issues/6
Originating issue: https://github.com/ipfs/kubo/issues/9125

This PR is intended to update examples so that users will be pointed to `kubo-rpc-client` instead of `ipfs-http-client` when using Javascript/TypeScript to talk to Kubo.

fixes https://github.com/ipfs/js-kubo-rpc-client/issues/37

Things for reviewers to check:

1. Confirm I didn't miss any areas that should be updated (old mentions that should be updated that aren't yet)
2. Confirm the added information is accurate and desired
3. Confirm that the language used is aligned with maintainers' intentions
